### PR TITLE
Init(*): ESLint, Prettier 세팅

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,16 @@
+/** @type {import("prettier").Config} */
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'es5',
+  printWidth: 80,
+  endOfLine: 'lf',
+
+  importOrder: ['^react', '^next', '^@lococo/(.*)$', '^@/(.*)$', '^[./]'],
+
+  plugins: [
+    '@trivago/prettier-plugin-sort-imports',
+    //   'prettier-plugin-tailwindcss',
+  ],
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
   "cSpell.words": ["lococo", "LOKOKO", "turbopack", "turborepo"],
   "files.associations": {
     "*.css": "tailwindcss"
+  },
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check-types": "turbo run check-types"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "prettier": "^3.6.0",
     "turbo": "^2.5.4",
     "typescript": "5.8.2"

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -1,8 +1,8 @@
-import js from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
-import turboPlugin from "eslint-plugin-turbo";
-import tseslint from "typescript-eslint";
-import onlyWarn from "eslint-plugin-only-warn";
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import turboPlugin from 'eslint-plugin-turbo';
+import tseslint from 'typescript-eslint';
+import onlyWarn from 'eslint-plugin-only-warn';
 
 /**
  * A shared ESLint configuration for the repository.
@@ -10,23 +10,70 @@ import onlyWarn from "eslint-plugin-only-warn";
  * @type {import("eslint").Linter.Config[]}
  * */
 export const config = [
-  js.configs.recommended,
-  eslintConfigPrettier,
-  ...tseslint.configs.recommended,
-  {
-    plugins: {
-      turbo: turboPlugin,
+    js.configs.recommended,
+    eslintConfigPrettier,
+    ...tseslint.configs.recommended,
+    {
+        languageOptions: {
+            parser: tseslint.parser,
+            parserOptions: {
+                project: true,
+            },
+        },
     },
-    rules: {
-      "turbo/no-undeclared-env-vars": "warn",
+    {
+        plugins: {
+            turbo: turboPlugin,
+        },
+        rules: {
+            'turbo/no-undeclared-env-vars': 'warn',
+        },
     },
-  },
-  {
-    plugins: {
-      onlyWarn,
+    {
+        plugins: {
+            onlyWarn,
+        },
     },
-  },
-  {
-    ignores: ["dist/**"],
-  },
+    {
+        ignores: ['dist/**'],
+    },
+    // 로코코 내부 컨벤션
+    {
+        rules: {
+            // any 사용 제한
+            '@typescript-eslint/no-explicit-any': 'error',
+
+            // 네이밍 컨벤션
+            '@typescript-eslint/naming-convention': [
+                'error',
+                // 변수명: 카멜케이스
+                {
+                    selector: 'variable',
+                    format: ['camelCase'],
+                    filter: {
+                        regex: '^[A-Z][A-Z0-9_]*$',
+                        match: false,
+                    },
+                },
+                // boolean 변수: is 접두사
+                {
+                    selector: 'variable',
+                    types: ['boolean'],
+                    format: ['camelCase'],
+                    prefix: ['is'],
+                },
+                // 상수: 대문자 스네이크케이스
+                {
+                    selector: 'variable',
+                    modifiers: ['const'],
+                    format: ['camelCase', 'UPPER_CASE'],
+                },
+                // 타입/인터페이스: 파스칼케이스
+                {
+                    selector: 'typeLike',
+                    format: ['PascalCase'],
+                },
+            ],
+        },
+    },
 ];

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -14,6 +14,7 @@ export const config = [
     eslintConfigPrettier,
     ...tseslint.configs.recommended,
     {
+        files: ['**/*.ts', '**/*.tsx'],
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/react-internal";
+import { config } from '@lococo/eslint-config/react-internal';
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/ui/src/code.tsx
+++ b/packages/ui/src/code.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from "react";
+import { type JSX } from 'react';
 
 export function Code({
   children,

--- a/packages/ui/src/test-eslint.tsx
+++ b/packages/ui/src/test-eslint.tsx
@@ -14,21 +14,21 @@ const user_name = 'john';
 const userName = 'john';
 
 type userInfo = {
-    name: string;
+  name: string;
 };
 
 type UserInfo = {
-    name: string;
+  name: string;
 };
 
 interface userProfile {
-    age: number;
+  age: number;
 }
 
 interface UserProfile {
-    age: number;
+  age: number;
 }
 
 export default function TestComponent() {
-    return <div>ESLint Test</div>;
+  return <div>ESLint Test</div>;
 }

--- a/packages/ui/src/test-eslint.tsx
+++ b/packages/ui/src/test-eslint.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const anyVariable: any = 'test';
+
+const enabled = true;
+
+const isEnabled = true;
+
+const API_URL = 'https://api.example.com';
+const apiUrl = 'https://api.example.com';
+
+const user_name = 'john';
+
+const userName = 'john';
+
+type userInfo = {
+    name: string;
+};
+
+type UserInfo = {
+    name: string;
+};
+
+interface userProfile {
+    age: number;
+}
+
+interface UserProfile {
+    age: number;
+}
+
+export default function TestComponent() {
+    return <div>ESLint Test</div>;
+}

--- a/packages/ui/src/test-prettier.tsx
+++ b/packages/ui/src/test-prettier.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@lococo/ui/button';
+
+interface Props {
+  name: string;
+  age: number;
+  isActive: boolean;
+}
+
+const TestComponent = ({ name, age, isActive }: Props) => {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    console.log('effect');
+  }, []);
+
+  return (
+    <div className="flex items-center justify-center p-4 bg-red-500 text-white hover:bg-red-600">
+      <Button onClick={() => setCount(count + 1)} className="mr-2 px-4 py-2">
+        Click me
+      </Button>
+      <span>Count: {count}</span>
+    </div>
+  );
+};
+
+export default TestComponent;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^5.2.2
+        version: 5.2.2(prettier@3.6.0)
       prettier:
         specifier: ^3.6.0
         version: 3.6.0
@@ -182,8 +185,41 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.5':
+    resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.7':
+    resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime-corejs3@7.27.0':
     resolution: {integrity: sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.7':
+    resolution: {integrity: sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.7':
+    resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -723,6 +759,22 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@trivago/prettier-plugin-sort-imports@5.2.2':
+    resolution: {integrity: sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==}
+    engines: {node: '>18.12'}
+    peerDependencies:
+      '@vue/compiler-sfc': 3.x
+      prettier: 2.x - 3.x
+      prettier-plugin-svelte: 3.x
+      svelte: 4.x || 5.x
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      svelte:
+        optional: true
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -1386,6 +1438,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
 
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1665,6 +1721,9 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -1677,6 +1736,11 @@ packages:
 
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2557,10 +2621,55 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@7.27.5':
+    dependencies:
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.27.7':
+    dependencies:
+      '@babel/types': 7.27.7
+
   '@babel/runtime-corejs3@7.27.0':
     dependencies:
       core-js-pure: 3.41.0
       regenerator-runtime: 0.14.1
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
+
+  '@babel/traverse@7.27.7':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
+      debug: 4.4.1
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.27.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2991,6 +3100,18 @@ snapshots:
       tailwindcss: 4.1.10
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.0)':
+    dependencies:
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/traverse': 7.27.7
+      '@babel/types': 7.27.7
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 3.6.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -3898,6 +4019,8 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  globals@11.12.0: {}
+
   globals@14.0.0: {}
 
   globals@16.2.0: {}
@@ -4201,6 +4324,8 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  javascript-natural-sort@0.7.1: {}
+
   jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
@@ -4210,6 +4335,8 @@ snapshots:
       argparse: 2.0.1
 
   jsbn@1.1.0: {}
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary
<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->
> close: #5 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->
터보레포 기본 eslint-config구조(base.js -> next.js -> eslint.config.mjs 순서로 상속)에 따라 base.js에 lint 설정하였습니다.
기본 ts, js 권장 ESLint 규칙에 변수명(기본 camelCase, boolean 변수에는 is 붙이고 상수는 대문자) 컨벤션, 타입명(PascalCase) 규칙을 팀 컨벤션에 맞춰 추가했습니다.
import 순서 정렬은 prettier에서 적용했습니다.(`pnpm add -D @trivago/prettier-plugin-sort-imports prettier-plugin -w`)
탭 간격은 2칸으로 했어요

## Tasks
<!-- 작업한 내용을 상세히 작성해주세요 -->
- [X] 루트 경로에 prettier 세팅
- [X] `/packages/eslint-config/base.js`에 eslint 세팅
- [ ] 전체 파일 포맷팅 적용하기(리뷰 반영할 것들 반영하고 머지 직전에 할게요!)
- [ ] 테스트용 파일(test-prettier.tsx, test-eslint.tsx) 삭제(이것도 머지 직전에 할게요!)

## To Reviewer
<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
- `base.js`, `next.js`, `apps내부 eslint` 구조는 터보레포에서 기본적으로 제공하는 구조인 것으로 이해해서 `base.js`에 기본 설정하면 나머지 두 곳에서 상속되어 `base.js`에 세팅하였습니다
- prettier는 기본 구조로 설정된게 없어서 루트에 세팅했어요
- lint설정처럼 prettier도 각 패키지에서 상속하면서 설정하는 방식도 있다고 하는데 굳이 불필요할 것 같다고 생각하여 루트에 세팅했습니다 리뷰로 의견 남겨주시면 반영하겠습니다
- import 순서 정렬은 적용했는데 AI가 tailwind css 적용하는 순서 정렬도 추천해주더라구요 tailwind에서 공식으로 권장하는 순서라는데(layout, flexbox/grid, spacing, sizing... 순서) 컨벤션 회의에서 얘기 나누지 않은 부분이라 주석처리해두고 반영은 안 시켰는데 가독성에 도움이 될 것 같아서 이것도 의견 나눠보면 좋을 것 같습니다
